### PR TITLE
travis: ignore decryption errors for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 - linux
 before_install:
 - openssl aes-256-cbc -K $encrypted_0098ef8519ef_key -iv $encrypted_0098ef8519ef_iv
-  -in test_service_account.json.enc -out storage/gcs/test_service_account.json -d
+  -in test_service_account.json.enc -out storage/gcs/test_service_account.json -d || echo OK
 install: make travis-setup
 script: make travis
 env:

--- a/storage/gcs/gcs_storage_test.go
+++ b/storage/gcs/gcs_storage_test.go
@@ -17,10 +17,15 @@ func TestGCSStorage(t *testing.T) {
 		t.Skip("KOPIA_GCS_TEST_BUCKET not provided")
 	}
 
+	credsFile := os.Getenv("KOPIA_GCS_CREDENTIALS_FILE")
+	if _, err := os.Stat(credsFile); err != nil {
+		t.Skip("skipping test because GCS credentials file can't be opened")
+	}
+
 	ctx := context.Background()
 	st, err := gcs.New(ctx, &gcs.Options{
 		BucketName:                bucket,
-		ServiceAccountCredentials: os.Getenv("KOPIA_GCS_CREDENTIALS_FILE"),
+		ServiceAccountCredentials: credsFile,
 	})
 
 	if err != nil {


### PR DESCRIPTION
since decryption does not work for pull requests, we ignore decryption errors and skip the test